### PR TITLE
Refactor RAG script into package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# RAG Chatbot
+
+TOC-aware hybrid Retrieval-Augmented Generation (RAG) pipeline for PDFs using LangChain and Ollama.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Ask a single question:
+
+```bash
+python rag_pdf_ollama.py --pdf /path/manual.pdf --ask "What export formats are supported?"
+```
+
+Interactive session:
+
+```bash
+python rag_pdf_ollama.py --pdf /path/manual.pdf --interactive
+```
+
+You can specify alternative Ollama models via `--model` and `--embed`.
+
+For direct module execution, ensure the `src` directory is on `PYTHONPATH` and run:
+
+```bash
+PYTHONPATH=src python -m rag_chatbot.cli --help
+```

--- a/rag_pdf_ollama.py
+++ b/rag_pdf_ollama.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+# Allow running the script directly without installing the package
+sys.path.append(str(Path(__file__).resolve().parent / "src"))
+
+from rag_chatbot.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+langchain
+langchain-community
+pypdf
+faiss-cpu
+rank-bm25
+sentence-transformers
+rapidfuzz

--- a/src/rag_chatbot/__init__.py
+++ b/src/rag_chatbot/__init__.py
@@ -1,0 +1,1 @@
+"""Core package for TOC-aware Hybrid RAG chatbot."""

--- a/src/rag_chatbot/answer.py
+++ b/src/rag_chatbot/answer.py
@@ -1,0 +1,73 @@
+from typing import List, Tuple
+
+from langchain_community.llms import Ollama
+
+from .chunking import Chunk
+from .index import Index
+from .retrieval import (
+    bm25_search,
+    dense_search,
+    expand_neighborhood,
+    maybe_rerank,
+    multi_query_expand,
+    rrf_fuse,
+)
+
+
+def pack_context(ix: Index, ordered_ids: List[str]) -> List[Chunk]:
+    kept: List[Chunk] = []
+    total = 0
+    for cid in ordered_ids:
+        ch = ix.chunks.get(cid)
+        if not ch:
+            continue
+        if len(kept) >= ix.cfg.max_context_chunks:
+            break
+        if total + len(ch.text) + 200 > ix.cfg.max_context_chars:
+            continue
+        kept.append(ch)
+        total += len(ch.text) + 200
+    return kept
+
+
+def render_context(keep: List[Chunk]) -> str:
+    blocks = []
+    for ch in keep:
+        header = f"{ch.toc_path} {ch.citation()}"
+        body = ch.text
+        blocks.append(f"### {header}\n{body}")
+    return "\n\n".join(blocks)
+
+
+def answer_query(ix: Index, query: str) -> Tuple[str, List[Chunk]]:
+    variants = multi_query_expand(query, ix.cfg)
+
+    dense_rankings: List[List[str]] = []
+    bm25_rankings: List[List[str]] = []
+    for v in variants:
+        dense_rankings.append(dense_search(ix, v, ix.cfg.topk_dense))
+        bm25_rankings.append(bm25_search(ix, v, ix.cfg.topk_bm25))
+
+    fused = rrf_fuse(dense_rankings + bm25_rankings, k=ix.cfg.rrf_k)
+    expanded = expand_neighborhood(ix, fused)
+    reranked = maybe_rerank(ix, query, expanded)
+
+    kept = pack_context(ix, reranked)
+    ctx = render_context(kept)
+
+    llm = Ollama(model=ix.cfg.llm_model)
+    sys_prompt = (
+        "You answer questions using the provided manual excerpts. "
+        "Cite after each claim with the chunk header in square brackets as already provided (e.g., [Export › CSV — p14]). "
+        "If information is missing, say so."
+    )
+    user_prompt = f"""
+Question: {query}
+
+Use ONLY the following context. Summarize across sibling sections when needed, and enumerate options clearly.
+
+{ctx}
+""".strip()
+    full_prompt = f"<|system|>\n{sys_prompt}\n<|user|>\n{user_prompt}"
+    ans = llm.invoke(full_prompt)
+    return ans.strip(), kept

--- a/src/rag_chatbot/chunking.py
+++ b/src/rag_chatbot/chunking.py
@@ -1,0 +1,222 @@
+import math
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from .config import Config
+
+
+@dataclass
+class Chunk:
+    id: str
+    text: str
+    toc_path: str
+    page_start: int
+    page_end: int
+    heading_num: str
+    heading_title: str
+    heading_level: int
+    ordinal_in_section: int
+    parent_key: str
+    prev_id: Optional[str] = None
+    next_id: Optional[str] = None
+
+    def citation(self) -> str:
+        pages = f"p{self.page_start}–{self.page_end}" if self.page_start != self.page_end else f"p{self.page_start}"
+        return f"[{self.toc_path} — {pages}]"
+
+
+HEADING_RE = re.compile(r"^\s*(?P<num>\d+(?:\.\d+)*)\s+(?P<title>[^\n]{1,120}?)(?:\.\s*|\s*)$", re.MULTILINE)
+
+
+def normalize_ws(s: str) -> str:
+    return re.sub(r"[ \t]+", " ", s).strip()
+
+
+def token_len(s: str) -> int:
+    # rough token proxy ~4 chars/token
+    return max(1, math.ceil(len(s) / 4))
+
+
+def split_paragraphs(s: str) -> List[str]:
+    parts = re.split(r"\n{2,}", s)
+    merged: List[str] = []
+    buff: List[str] = []
+    for p in parts:
+        if re.match(r"^\s*([\-*•\d]+\.|[\-*•])\s+", p):
+            buff.append(p)
+            continue
+        if buff:
+            merged.append("\n\n".join(buff))
+            buff = []
+        merged.append(p)
+    if buff:
+        merged.append("\n\n".join(buff))
+    return [normalize_ws(x.replace("\n", " ")) for x in merged if normalize_ws(x)]
+
+
+def detect_headings(pages: List[Tuple[int, str]]):
+    headings = []
+    for page_no, text in pages:
+        for m in HEADING_RE.finditer(text):
+            num = m.group("num").strip()
+            title = m.group("title").strip().rstrip(" .")
+            if len(title) < 2:
+                continue
+            headings.append({
+                "num": num,
+                "title": title,
+                "page": page_no,
+                "span": m.span(),
+            })
+    deduped = []
+    seen: List[Tuple[int, str]] = []
+    for h in headings:
+        key = (h["page"], h["num"])
+        if key in seen:
+            continue
+        seen.append(key)
+        deduped.append(h)
+    return deduped
+
+
+def build_toc_paths(headings: List[Dict[str, Any]]) -> Dict[str, str]:
+    title_by_num: Dict[str, str] = {}
+    for h in headings:
+        title_by_num[h["num"]] = h["title"]
+
+    path_by_num: Dict[str, str] = {}
+    for num in title_by_num:
+        parts = num.split(".")
+        crumbs = []
+        for i in range(1, len(parts) + 1):
+            pnum = ".".join(parts[:i])
+            title = title_by_num.get(pnum)
+            if title:
+                crumbs.append(f"{pnum} — {title}")
+        path_by_num[num] = " › ".join([c.split(" — ", 1)[1] for c in crumbs]) if crumbs else num
+    return path_by_num
+
+
+def parent_key(num: str) -> str:
+    parts = num.split(".")
+    return ".".join(parts[:-1]) if len(parts) > 1 else ""
+
+
+def chunk_section(text: str, base_meta: Dict[str, Any], cfg: Config) -> List[Chunk]:
+    paras = split_paragraphs(text)
+    chunks: List[Chunk] = []
+    buf: List[str] = []
+    tokens = 0
+    idx_in_sec = 0
+
+    def flush():
+        nonlocal buf, tokens, idx_in_sec, chunks
+        if not buf:
+            return
+        chunk_text = "\n\n".join(buf).strip()
+        if not chunk_text:
+            buf = []
+            tokens = 0
+            return
+        cid = str(uuid.uuid4())
+        chunk = Chunk(
+            id=cid,
+            text=chunk_text,
+            toc_path=base_meta["toc_path"],
+            page_start=base_meta["page_start"],
+            page_end=base_meta["page_end"],
+            heading_num=base_meta["heading_num"],
+            heading_title=base_meta["heading_title"],
+            heading_level=base_meta["heading_level"],
+            ordinal_in_section=idx_in_sec,
+            parent_key=base_meta["parent_key"],
+        )
+        chunks.append(chunk)
+        idx_in_sec += 1
+        if cfg.atomic_chunk_overlap_tokens > 0 and len(buf) > 0:
+            keep = []
+            tks = 0
+            for p in reversed(buf):
+                tks += token_len(p)
+                keep.append(p)
+                if tks >= cfg.atomic_chunk_overlap_tokens:
+                    break
+            buf = list(reversed(keep))
+            tokens = sum(token_len(x) for x in buf)
+        else:
+            buf = []
+            tokens = 0
+
+    for p in paras:
+        p_tokens = token_len(p)
+        if tokens + p_tokens > cfg.atomic_chunk_tokens and tokens > 0:
+            flush()
+        buf.append(p)
+        tokens += p_tokens
+    flush()
+    return chunks
+
+
+def build_chunks(pages: List[Tuple[int, str]], cfg: Config) -> List[Chunk]:
+    headings = detect_headings(pages)
+    if not headings:
+        full_text = "\n\n".join([t for _, t in pages])
+        base = {
+            "toc_path": "Document",
+            "page_start": 1,
+            "page_end": len(pages),
+            "heading_num": "0",
+            "heading_title": "Document",
+            "heading_level": 0,
+            "parent_key": "",
+        }
+        return chunk_section(full_text, base, cfg)
+
+    headings.sort(key=lambda h: (h["page"], h["span"][0]))
+    path_by_num = build_toc_paths(headings)
+
+    page_map = {p: t for p, t in pages}
+    sections: List[Tuple[Dict[str, Any], str, int, int]] = []
+
+    for idx, h in enumerate(headings):
+        start_page = h["page"]
+        start_off = h["span"][1]
+        end_page = pages[-1][0]
+        end_off = len(page_map[end_page])
+        if idx + 1 < len(headings):
+            nh = headings[idx + 1]
+            end_page = nh["page"]
+            end_off = nh["span"][0]
+        if start_page == end_page:
+            body = page_map[start_page][start_off:end_off]
+        else:
+            parts = [page_map[start_page][start_off:]]
+            for p in range(start_page + 1, end_page):
+                parts.append(page_map[p])
+            parts.append(page_map[end_page][:end_off])
+            body = "\n".join(parts)
+        body = body.strip()
+        sections.append((h, body, start_page, end_page))
+
+    all_chunks: List[Chunk] = []
+    for h, body, pstart, pend in sections:
+        meta = {
+            "toc_path": path_by_num.get(h["num"], h["title"]),
+            "page_start": pstart,
+            "page_end": pend,
+            "heading_num": h["num"],
+            "heading_title": h["title"],
+            "heading_level": len(h["num"].split(".")),
+            "parent_key": parent_key(h["num"]),
+        }
+        chs = chunk_section(body, meta, cfg)
+        all_chunks.extend(chs)
+
+    for i, ch in enumerate(all_chunks):
+        if i > 0:
+            ch.prev_id = all_chunks[i - 1].id
+        if i < len(all_chunks) - 1:
+            ch.next_id = all_chunks[i + 1].id
+    return all_chunks

--- a/src/rag_chatbot/cli.py
+++ b/src/rag_chatbot/cli.py
@@ -1,0 +1,71 @@
+import argparse
+import os
+import sys
+
+from .answer import answer_query
+from .chunking import build_chunks
+from .config import Config
+from .index import build_index
+from .pdf_utils import load_pdf_text
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="TOC‑aware Hybrid RAG for PDFs (LangChain + Ollama)")
+    parser.add_argument("--pdf", help="Path to the PDF user manual", default="data/Manual_ver3.pdf")
+    parser.add_argument("--ask", help="Single question to ask")
+    parser.add_argument("--interactive", action="store_true", help="Interactive Q&A loop")
+    parser.add_argument("--model", help="Ollama LLM model (default llama3.2:3b)")
+    parser.add_argument("--embed", help="Ollama embedding model (default bge-m3, fallback nomic-embed-text)")
+    args = parser.parse_args()
+
+    cfg = Config()
+    if args.model:
+        cfg.llm_model = args.model
+    if args.embed:
+        cfg.embed_model_primary = args.embed
+
+    if not os.path.exists(args.pdf):
+        print(f"PDF not found: {args.pdf}", file=sys.stderr)
+        sys.exit(1)
+
+    print("[1/4] Reading PDF …", file=sys.stderr)
+    pages = load_pdf_text(args.pdf)
+
+    print("[2/4] Building chunks …", file=sys.stderr)
+    chunks = build_chunks(pages, cfg)
+    print(f"  chunks: {len(chunks)}")
+
+    print("[3/4] Building hybrid index (FAISS + BM25) …", file=sys.stderr)
+    ix = build_index(chunks, cfg)
+
+    def ask(q: str) -> None:
+        print("\n[4/4] Retrieving & answering …", file=sys.stderr)
+        ans, used = answer_query(ix, q)
+        print("\n=== ANSWER ===\n")
+        print(ans)
+        print("\n--- Sources ---")
+        seen = set()
+        for ch in used:
+            key = (ch.toc_path, ch.page_start, ch.page_end)
+            if key in seen:
+                continue
+            seen.add(key)
+            print(f"• {ch.citation()}")
+
+    if args.ask:
+        ask(args.ask)
+    if args.interactive:
+        print("\nInteractive mode. Type your question (or 'exit').\n")
+        while True:
+            try:
+                q = input("? ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                break
+            if not q or q.lower() in {"exit", "quit"}:
+                break
+            ask(q)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rag_chatbot/config.py
+++ b/src/rag_chatbot/config.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Config:
+    """Runtime configuration for the RAG pipeline."""
+
+    # Models
+    llm_model: str = "llama3.2:3b"
+    embed_model_primary: str = "bge-m3"
+    embed_model_fallback: str = "nomic-embed-text"
+
+    # Chunking
+    atomic_chunk_tokens: int = 320
+    atomic_chunk_overlap_tokens: int = 48
+    max_section_tokens: int = 1100
+
+    # Retrieval
+    topk_dense: int = 8
+    topk_bm25: int = 8
+    rrf_k: int = 60
+    expand_neighbors: int = 1
+    expand_siblings: bool = True
+
+    # Reranker
+    use_reranker: bool = True
+    reranker_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+    # Context packing
+    max_context_chars: int = 9000
+    max_context_chunks: int = 12
+
+    # Prompting
+    n_query_expansions: int = 4

--- a/src/rag_chatbot/index.py
+++ b/src/rag_chatbot/index.py
@@ -1,0 +1,68 @@
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from langchain_community.embeddings import OllamaEmbeddings
+from langchain_community.vectorstores import FAISS
+from rank_bm25 import BM25Okapi
+
+from .config import Config
+from .chunking import Chunk
+
+
+@dataclass
+class Index:
+    cfg: Config
+    faiss: FAISS
+    id_lookup: List[str]
+    bm25: BM25Okapi
+    bm25_corpus_tokens: List[List[str]]
+    bm25_id_lookup: List[str]
+    chunks: Dict[str, Chunk] = field(default_factory=dict)
+    siblings_by_parent: Dict[str, List[str]] = field(default_factory=dict)
+
+
+def make_embeddings(cfg: Config) -> OllamaEmbeddings:
+    try:
+        return OllamaEmbeddings(model=cfg.embed_model_primary)
+    except Exception:
+        return OllamaEmbeddings(model=cfg.embed_model_fallback)
+
+
+def build_index(chunks: List[Chunk], cfg: Config) -> Index:
+    texts = [c.text for c in chunks]
+    metadatas = [{
+        "id": c.id,
+        "toc_path": c.toc_path,
+        "page_start": c.page_start,
+        "page_end": c.page_end,
+        "heading_num": c.heading_num,
+        "heading_title": c.heading_title,
+        "heading_level": c.heading_level,
+        "ordinal_in_section": c.ordinal_in_section,
+        "parent_key": c.parent_key,
+    } for c in chunks]
+
+    embeddings = make_embeddings(cfg)
+    vectorstore = FAISS.from_texts(texts=texts, embedding=embeddings, metadatas=metadatas)
+
+    def tok(s: str) -> List[str]:
+        return re.findall(r"[a-z0-9]+", s.lower())
+    corpus_tokens = [tok(t) for t in texts]
+    bm25 = BM25Okapi(corpus_tokens)
+
+    id_lookup = [m.id for m in vectorstore.docstore._dict.values()]  # type: ignore
+    bm25_id_lookup = id_lookup[:]
+
+    sibs: Dict[str, List[str]] = {}
+    by_parent: Dict[str, List[Chunk]] = {}
+    for c in chunks:
+        by_parent.setdefault(c.parent_key, []).append(c)
+    for pk, lst in by_parent.items():
+        sibs[pk] = [c.id for c in lst]
+
+    chunk_map = {c.id: c for c in chunks}
+
+    return Index(cfg=cfg, faiss=vectorstore, id_lookup=id_lookup, bm25=bm25,
+                 bm25_corpus_tokens=corpus_tokens, bm25_id_lookup=bm25_id_lookup,
+                 chunks=chunk_map, siblings_by_parent=sibs)

--- a/src/rag_chatbot/pdf_utils.py
+++ b/src/rag_chatbot/pdf_utils.py
@@ -1,0 +1,16 @@
+from typing import List, Tuple
+
+from pypdf import PdfReader
+
+
+def load_pdf_text(pdf_path: str) -> List[Tuple[int, str]]:
+    """Return list of (page_number starting at 1, page_text)."""
+    reader = PdfReader(pdf_path)
+    pages: List[Tuple[int, str]] = []
+    for i, page in enumerate(reader.pages):
+        try:
+            txt = page.extract_text() or ""
+        except Exception:
+            txt = ""
+        pages.append((i + 1, txt))
+    return pages

--- a/src/rag_chatbot/retrieval.py
+++ b/src/rag_chatbot/retrieval.py
@@ -1,0 +1,92 @@
+import re
+from typing import List, Dict
+
+from langchain_community.llms import Ollama
+from rapidfuzz import fuzz
+
+from .config import Config
+from .index import Index
+
+# Optional reranker
+try:
+    from sentence_transformers import CrossEncoder  # type: ignore
+    _HAS_RERANKER = True
+except Exception:  # pragma: no cover - optional dependency
+    _HAS_RERANKER = False
+
+
+def multi_query_expand(query: str, cfg: Config) -> List[str]:
+    llm = Ollama(model=cfg.llm_model)
+    prompt = f"""
+You are a retrieval assistant. Generate {cfg.n_query_expansions} diverse paraphrases and facet variants of the user's query. Be concise.
+
+User query: {query}
+
+Return each variant on its own line with no numbering.
+""".strip()
+    out = llm.invoke(prompt)
+    lines = [re.sub(r"[ \t]+", " ", x).strip() for x in out.splitlines() if re.sub(r"[ \t]+", " ", x).strip()]
+    uniq: List[str] = []
+    for s in lines:
+        if all(fuzz.token_sort_ratio(s, t) < 90 for t in uniq):
+            uniq.append(s)
+    if not uniq:
+        return [query]
+    return [query] + uniq[: cfg.n_query_expansions]
+
+
+def rrf_fuse(rankings: List[List[str]], k: int) -> List[str]:
+    scores: Dict[str, float] = {}
+    for ranking in rankings:
+        for r, cid in enumerate(ranking):
+            scores[cid] = scores.get(cid, 0.0) + 1.0 / (k + r + 1)
+    return [cid for cid, _ in sorted(scores.items(), key=lambda x: x[1], reverse=True)]
+
+
+def dense_search(ix: Index, query: str, topk: int) -> List[str]:
+    docs = ix.faiss.similarity_search(query, k=topk)
+    return [d.metadata.get("id") for d in docs]
+
+
+def bm25_search(ix: Index, query: str, topk: int) -> List[str]:
+    def tok(s: str) -> List[str]:
+        return re.findall(r"[a-z0-9]+", s.lower())
+
+    scores = ix.bm25.get_scores(tok(query))
+    ranked = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:topk]
+    return [ix.bm25_id_lookup[i] for i in ranked]
+
+
+def expand_neighborhood(ix: Index, base_ids: List[str]) -> List[str]:
+    cfg = ix.cfg
+    selected = set(base_ids)
+    if cfg.expand_neighbors > 0:
+        pos = {cid: i for i, cid in enumerate(ix.id_lookup)}
+        for cid in list(selected):
+            if cid not in pos:
+                continue
+            i = pos[cid]
+            for d in range(1, cfg.expand_neighbors + 1):
+                if i - d >= 0:
+                    selected.add(ix.id_lookup[i - d])
+                if i + d < len(ix.id_lookup):
+                    selected.add(ix.id_lookup[i + d])
+    if cfg.expand_siblings:
+        for cid in list(selected):
+            ch = ix.chunks.get(cid)
+            if not ch:
+                continue
+            sibs = ix.siblings_by_parent.get(ch.parent_key, [])
+            for s in sibs:
+                selected.add(s)
+    return list(selected)
+
+
+def maybe_rerank(ix: Index, query: str, candidate_ids: List[str]) -> List[str]:
+    if not (ix.cfg.use_reranker and _HAS_RERANKER and candidate_ids):
+        return candidate_ids
+    model = CrossEncoder(ix.cfg.reranker_model)
+    pairs = [(query, ix.chunks[cid].text) for cid in candidate_ids if cid in ix.chunks]
+    scores = model.predict(pairs)
+    ranked = [cid for _, cid in sorted(zip(scores, candidate_ids), key=lambda x: x[0], reverse=True)]
+    return ranked


### PR DESCRIPTION
## Summary
- split monolithic RAG script into modular `rag_chatbot` package
- add requirements and documentation
- provide wrapper script for direct execution

## Testing
- `python rag_pdf_ollama.py --help` *(fails: No module named 'langchain_community')*


------
https://chatgpt.com/codex/tasks/task_e_68af6eac9b6483309dbfbaee51f9d6e8