### PR TITLE
feat: modular reranking and model registry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 langchain
 langchain-community
 langchain-ollama
+langchain-aws
 pypdf
 faiss-cpu
 rank-bm25
 rapidfuzz
+sentence-transformers

--- a/src/rag_chatbot/answer.py
+++ b/src/rag_chatbot/answer.py
@@ -1,9 +1,8 @@
 from typing import List, Tuple
 
-from langchain_ollama import OllamaLLM
-
 from rag_chatbot.chunking import Chunk
 from rag_chatbot.index import Index
+from rag_chatbot.models import get_llm
 from rag_chatbot.prompt_registry import registry
 from rag_chatbot.retrieval import (
     bm25_search,
@@ -48,7 +47,7 @@ def answer_query(ix: Index, query: str) -> Tuple[str, List[Chunk]]:
 
     kept = pack_context(ix, reranked)
     ctx = render_context(kept)
-    llm = OllamaLLM(model=ix.cfg.llm_model)
+    llm = get_llm(ix.cfg.llm_model, provider=ix.cfg.llm_provider)
     sys_prompt = registry["answer_system"]
     user_prompt = registry["answer_user"].format(query=query, ctx=ctx)
     full_prompt = f"<|system|>\n{sys_prompt}\n<|user|>\n{user_prompt}"

--- a/src/rag_chatbot/cli.py
+++ b/src/rag_chatbot/cli.py
@@ -15,7 +15,7 @@ def main() -> None:
     parser.add_argument("--ask", help="Single question to ask")
     parser.add_argument("--interactive", action="store_true", help="Interactive Q&A loop")
     parser.add_argument("--model", help="Ollama LLM model (default llama3.2:3b)")
-    parser.add_argument("--embed", help="Ollama embedding model (default bge-m3, fallback nomic-embed-text)")
+    parser.add_argument("--embed", help="Ollama embedding model (default bge-m3)")
     parser.add_argument("--toc-pages", type=int, default=0, help="Number of initial table-of-contents pages to parse")
     parser.add_argument("--footer-regex", help="Regular expression to remove footer text from each page")
     args = parser.parse_args()
@@ -24,7 +24,7 @@ def main() -> None:
     if args.model:
         cfg.llm_model = args.model
     if args.embed:
-        cfg.embed_model_primary = args.embed
+        cfg.embed_model = args.embed
     if args.toc_pages:
         cfg.toc_pages = args.toc_pages
     if args.footer_regex:

--- a/src/rag_chatbot/config.py
+++ b/src/rag_chatbot/config.py
@@ -7,8 +7,9 @@ class Config:
 
     # Models
     llm_model: str = "llama3.2:3b"
-    embed_model_primary: str = "bge-m3"
-    embed_model_fallback: str = "nomic-embed-text"
+    llm_provider: str = "ollama"
+    embed_model: str = "bge-m3"
+    embed_provider: str = "ollama"
 
     # PDF pre-processing
     toc_pages: int = 0  # number of initial table-of-contents pages
@@ -28,7 +29,9 @@ class Config:
 
     # Reranker
     use_reranker: bool = True
-    reranker_model: str = "dengcao/Qwen3-Embedding-4B:Q5_K_M"
+    reranker_type: str = "cross-encoder"  # "llm" or "cross-encoder"
+    reranker_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    reranker_provider: str = "hf"
 
     # Context packing
     max_context_chars: int = 9000

--- a/src/rag_chatbot/models.py
+++ b/src/rag_chatbot/models.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+
+def get_llm(model_name: str, provider: str = "ollama", **kwargs: Any):
+    """Return an LLM instance for the given provider."""
+    if provider == "ollama":
+        from langchain_ollama import OllamaLLM
+
+        return OllamaLLM(model=model_name, **kwargs)
+    elif provider == "bedrock":
+        from langchain_aws import ChatBedrockConverse
+
+        return ChatBedrockConverse(model_id=model_name, **kwargs)
+    else:
+        raise ValueError(f"Unsupported LLM provider: {provider}")
+
+
+def get_embeddings(model_name: str, provider: str = "ollama", **kwargs: Any):
+    """Return an embeddings model for the given provider."""
+    if provider == "ollama":
+        from langchain_ollama import OllamaEmbeddings
+
+        return OllamaEmbeddings(model=model_name, **kwargs)
+    elif provider == "bedrock":
+        from langchain_aws import BedrockEmbeddings
+
+        return BedrockEmbeddings(model_id=model_name, **kwargs)
+    else:
+        raise ValueError(f"Unsupported embedding provider: {provider}")
+
+
+def get_cross_encoder(model_name: str, **kwargs: Any):
+    """Return a sentence-transformers CrossEncoder."""
+    from sentence_transformers import CrossEncoder
+
+    return CrossEncoder(model_name, **kwargs)

--- a/src/rag_chatbot/reranking.py
+++ b/src/rag_chatbot/reranking.py
@@ -1,0 +1,55 @@
+import re
+from typing import List
+
+from rag_chatbot.index import Index
+from rag_chatbot.models import get_llm, get_cross_encoder
+
+
+class BaseReranker:
+    """Base reranker interface."""
+
+    def rerank(self, ix: Index, query: str, candidate_ids: List[str]) -> List[str]:
+        raise NotImplementedError
+
+
+class LLMReranker(BaseReranker):
+    """Rerank using an LLM that scores relevance."""
+
+    def __init__(self, model_name: str, provider: str = "ollama") -> None:
+        self.llm = get_llm(model_name, provider=provider)
+
+    def rerank(self, ix: Index, query: str, candidate_ids: List[str]) -> List[str]:
+        pairs = [(cid, ix.chunks[cid].text) for cid in candidate_ids if cid in ix.chunks]
+        if not pairs:
+            return candidate_ids
+        scored = []
+        for cid, text in pairs:
+            prompt = (
+                "Given the query and document below, return a number between 0 and 1\n"
+                f"Query: {query}\nDocument: {text}\nScore:"
+            )
+            try:
+                out = self.llm.invoke(prompt)
+                match = re.search(r"[0-1]?\.\d+", out)
+                score = float(match.group()) if match else 0.0
+            except Exception:
+                score = 0.0
+            scored.append((score, cid))
+        ranked = [cid for _, cid in sorted(scored, key=lambda x: x[0], reverse=True)]
+        return ranked
+
+
+class CrossEncoderReranker(BaseReranker):
+    """Rerank using a sentence-transformers CrossEncoder model."""
+
+    def __init__(self, model_name: str, **kwargs) -> None:
+        self.model = get_cross_encoder(model_name, **kwargs)
+
+    def rerank(self, ix: Index, query: str, candidate_ids: List[str]) -> List[str]:
+        pairs = [(query, ix.chunks[cid].text) for cid in candidate_ids if cid in ix.chunks]
+        if not pairs:
+            return candidate_ids
+        scores = self.model.predict(pairs)
+        ids = [cid for cid, _ in pairs]
+        ranked = [cid for _, cid in sorted(zip(scores, ids), key=lambda x: x[0], reverse=True)]
+        return ranked


### PR DESCRIPTION
## Summary
- centralize LLM, embedding, and cross-encoder selection in `models.py`
- add `LLMReranker` and `CrossEncoderReranker` classes in new `reranking.py`
- wire retrieval and answering to configurable model providers
- extend configuration to specify providers and reranker type
- support AWS Bedrock with `ChatBedrockConverse` and `BedrockEmbeddings`
- drop embedding model fallback for simpler configuration

## Testing
- `pip install langchain-aws` *(fails: Could not find a version that satisfies the requirement langchain-aws)*
- `python -m py_compile src/rag_chatbot/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b19e70f2748330a83dbb1b1f6b6ced