### PR TITLE
Separate preprocessing pipeline and add optional summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,33 @@ pip install -r requirements.txt
 
 ## Usage
 
+### 1. Preprocess documents (run once)
+
+```bash
+python preprocess_pdf.py --pdf /path/manual.pdf --output data/index
+```
+
+Use `--config path.json` to override defaults from a JSON config file. Add
+`--summary` to generate optional summaries for chunks and sections. The
+preprocessing step builds the FAISS/BM25 index and stores it on disk so it can
+be reused by the chat CLI.
+
+### 2. Query the chatbot
+
 Ask a single question:
 
 ```bash
-python rag_pdf_ollama.py --pdf /path/manual.pdf --ask "What export formats are supported?"
+python rag_pdf_ollama.py --index data/index --ask "What export formats are supported?"
 ```
 
 Interactive session:
 
 ```bash
-python rag_pdf_ollama.py --pdf /path/manual.pdf --interactive
+python rag_pdf_ollama.py --index data/index --interactive
 ```
 
-You can specify alternative Ollama models via `--model` and `--embed`.
-
-If the PDF has a table of contents or repetitive footers you want to
-handle specially, the CLI offers additional options:
-
-```bash
-python rag_pdf_ollama.py --pdf /path/manual.pdf --toc-pages 5 --footer-regex "Footer text"
-```
-
-* `--toc-pages` – number of initial pages that form the table of contents (they are parsed but not chunked).
-* `--footer-regex` – regular expression removed from each page (useful for footers).
+The chat CLI allows overriding the answering model and provider via
+`--model` and `--llm-provider`.
 
 For direct module execution, ensure the `src` directory is on `PYTHONPATH` and run:
 

--- a/configs/prompts/summarize_chunk.txt
+++ b/configs/prompts/summarize_chunk.txt
@@ -1,0 +1,3 @@
+Summarize the following text in one or two sentences.
+
+{text}

--- a/configs/prompts/summarize_section.txt
+++ b/configs/prompts/summarize_section.txt
@@ -1,0 +1,3 @@
+Provide a brief summary for the section titled "{title}" using the text below.
+
+{text}

--- a/preprocess_pdf.py
+++ b/preprocess_pdf.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+# Allow running the script directly without installing the package
+sys.path.append(str(Path(__file__).resolve().parent / "src"))
+
+from rag_chatbot.preprocess_cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/rag_chatbot/index.py
+++ b/src/rag_chatbot/index.py
@@ -1,6 +1,8 @@
+import os
+import pickle
 import re
-from dataclasses import dataclass, field
-from typing import Dict, List
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Optional
 
 from langchain_community.vectorstores import FAISS
 from rank_bm25 import BM25Okapi
@@ -22,21 +24,45 @@ class Index:
     bm25_id_lookup: List[str]
     chunks: Dict[str, Chunk] = field(default_factory=dict)
     siblings_by_parent: Dict[str, List[str]] = field(default_factory=dict)
+    chunk_summaries: Dict[str, str] = field(default_factory=dict)
+    section_summaries: Dict[str, str] = field(default_factory=dict)
 
 
-def build_index(chunks: List[Chunk], cfg: Config) -> Index:
-    texts = [c.text for c in chunks]
-    metadatas = [{
-        "id": c.id,
-        "toc_path": c.toc_path,
-        "page_start": c.page_start,
-        "page_end": c.page_end,
-        "heading_num": c.heading_num,
-        "heading_title": c.heading_title,
-        "heading_level": c.heading_level,
-        "ordinal_in_section": c.ordinal_in_section,
-        "parent_key": c.parent_key,
-    } for c in chunks]
+def build_index(
+    chunks: List[Chunk],
+    cfg: Config,
+    chunk_summaries: Optional[Dict[str, str]] = None,
+    section_summaries: Optional[Dict[str, str]] = None,
+) -> Index:
+    chunk_summaries = chunk_summaries or {}
+    section_summaries = section_summaries or {}
+
+    texts = []
+    metadatas = []
+    for c in chunks:
+        text_parts = [c.text]
+        if c.id in chunk_summaries:
+            text_parts.append(chunk_summaries[c.id])
+        sec_sum = section_summaries.get(c.heading_num)
+        if sec_sum:
+            text_parts.append(sec_sum)
+        texts.append("\n".join(text_parts))
+        meta = {
+            "id": c.id,
+            "toc_path": c.toc_path,
+            "page_start": c.page_start,
+            "page_end": c.page_end,
+            "heading_num": c.heading_num,
+            "heading_title": c.heading_title,
+            "heading_level": c.heading_level,
+            "ordinal_in_section": c.ordinal_in_section,
+            "parent_key": c.parent_key,
+        }
+        if c.id in chunk_summaries:
+            meta["chunk_summary"] = chunk_summaries[c.id]
+        if sec_sum:
+            meta["section_summary"] = sec_sum
+        metadatas.append(meta)
 
     embeddings = get_embeddings(cfg.embed_model, provider=cfg.embed_provider)
     vectorstore = FAISS.from_texts(texts=texts, embedding=embeddings, metadatas=metadatas)
@@ -56,6 +82,60 @@ def build_index(chunks: List[Chunk], cfg: Config) -> Index:
 
     chunk_map = {c.id: c for c in chunks}
 
-    return Index(cfg=cfg, faiss=vectorstore, id_lookup=id_lookup, bm25=bm25,
-                 bm25_corpus_tokens=corpus_tokens, bm25_id_lookup=bm25_id_lookup,
-                 chunks=chunk_map, siblings_by_parent=sibs)
+    return Index(
+        cfg=cfg,
+        faiss=vectorstore,
+        id_lookup=id_lookup,
+        bm25=bm25,
+        bm25_corpus_tokens=corpus_tokens,
+        bm25_id_lookup=bm25_id_lookup,
+        chunks=chunk_map,
+        siblings_by_parent=sibs,
+        chunk_summaries=chunk_summaries,
+        section_summaries=section_summaries,
+    )
+
+
+def save_index(ix: Index, path: str) -> None:
+    """Persist an index to disk."""
+    os.makedirs(path, exist_ok=True)
+    ix.faiss.save_local(os.path.join(path, "faiss"))
+    meta = {
+        "cfg": asdict(ix.cfg),
+        "id_lookup": ix.id_lookup,
+        "bm25_corpus_tokens": ix.bm25_corpus_tokens,
+        "bm25_id_lookup": ix.bm25_id_lookup,
+        "chunks": [asdict(ch) for ch in ix.chunks.values()],
+        "siblings_by_parent": ix.siblings_by_parent,
+        "chunk_summaries": ix.chunk_summaries,
+        "section_summaries": ix.section_summaries,
+    }
+    with open(os.path.join(path, "meta.pkl"), "wb") as f:
+        pickle.dump(meta, f)
+
+
+def load_index(path: str) -> Index:
+    """Load a previously saved index from disk."""
+    with open(os.path.join(path, "meta.pkl"), "rb") as f:
+        meta = pickle.load(f)
+
+    cfg = Config(**meta["cfg"])
+    embeddings = get_embeddings(cfg.embed_model, provider=cfg.embed_provider)
+    faiss_store = FAISS.load_local(os.path.join(path, "faiss"), embeddings, allow_dangerous_deserialization=True)
+
+    corpus_tokens = meta["bm25_corpus_tokens"]
+    bm25 = BM25Okapi(corpus_tokens)
+    chunk_objs = {c["id"]: Chunk(**c) for c in meta["chunks"]}
+
+    return Index(
+        cfg=cfg,
+        faiss=faiss_store,
+        id_lookup=meta["id_lookup"],
+        bm25=bm25,
+        bm25_corpus_tokens=corpus_tokens,
+        bm25_id_lookup=meta["bm25_id_lookup"],
+        chunks=chunk_objs,
+        siblings_by_parent=meta["siblings_by_parent"],
+        chunk_summaries=meta.get("chunk_summaries", {}),
+        section_summaries=meta.get("section_summaries", {}),
+    )

--- a/src/rag_chatbot/preprocess_cli.py
+++ b/src/rag_chatbot/preprocess_cli.py
@@ -1,0 +1,62 @@
+import argparse
+import json
+import os
+import sys
+
+from rag_chatbot.chunking import build_chunks
+from rag_chatbot.config import Config
+from rag_chatbot.index import build_index, save_index
+from rag_chatbot.pdf_utils import load_pdf_text
+from rag_chatbot.summary import build_summaries
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Preprocess a PDF into a searchable index")
+    parser.add_argument("--pdf", required=True, help="Path to the PDF file")
+    parser.add_argument(
+        "--output", default="data/index", help="Directory to store the index"
+    )
+    parser.add_argument(
+        "--config", help="Path to JSON config file overriding defaults"
+    )
+    parser.add_argument(
+        "--summary", action="store_true", help="Generate chunk and section summaries"
+    )
+    args = parser.parse_args()
+
+    cfg = Config()
+    if args.config:
+        with open(args.config, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        for k, v in data.items():
+            if hasattr(cfg, k):
+                setattr(cfg, k, v)
+
+    if not os.path.exists(args.pdf):
+        print(f"PDF not found: {args.pdf}", file=sys.stderr)
+        sys.exit(1)
+
+    print("[1/4] Reading PDF …", file=sys.stderr)
+    pages = load_pdf_text(args.pdf)
+
+    print("[2/4] Building chunks …", file=sys.stderr)
+    chunks = build_chunks(pages, cfg)
+    print(f"  chunks: {len(chunks)}", file=sys.stderr)
+
+    chunk_sums = {}
+    section_sums = {}
+    if args.summary:
+        print("[3/4] Generating summaries …", file=sys.stderr)
+        sums = build_summaries(chunks, cfg)
+        chunk_sums = sums["chunks"]
+        section_sums = sums["sections"]
+
+    print("[4/4] Building index …", file=sys.stderr)
+    ix = build_index(chunks, cfg, chunk_sums, section_sums)
+
+    save_index(ix, args.output)
+    print(f"Index saved to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rag_chatbot/summary.py
+++ b/src/rag_chatbot/summary.py
@@ -1,0 +1,39 @@
+"""Utilities for generating optional summaries of chunks and sections."""
+from collections import defaultdict
+from typing import Dict, List
+
+from rag_chatbot.chunking import Chunk
+from rag_chatbot.config import Config
+from rag_chatbot.models import get_llm
+from rag_chatbot.prompt_registry import registry
+
+
+def build_summaries(chunks: List[Chunk], cfg: Config) -> Dict[str, Dict[str, str]]:
+    """Generate summaries for individual chunks and whole sections.
+
+    Returns a dictionary with two keys: ``chunks`` and ``sections`` mapping to
+    summary strings.
+    """
+    llm = get_llm(cfg.llm_model, provider=cfg.llm_provider)
+
+    chunk_summaries: Dict[str, str] = {}
+    for ch in chunks:
+        prompt = registry.get("summarize_chunk", "Summarize:\n{text}")
+        chunk_summaries[ch.id] = llm.invoke(prompt.format(text=ch.text)).strip()
+
+    by_section: Dict[str, List[Chunk]] = defaultdict(list)
+    for ch in chunks:
+        by_section[ch.heading_num].append(ch)
+
+    section_summaries: Dict[str, str] = {}
+    for num, chs in by_section.items():
+        text = "\n\n".join(c.text for c in chs)
+        title = chs[0].heading_title
+        prompt = registry.get(
+            "summarize_section", "Summarize section '{title}':\n{text}"
+        )
+        section_summaries[num] = llm.invoke(
+            prompt.format(title=title, text=text)
+        ).strip()
+
+    return {"chunks": chunk_summaries, "sections": section_summaries}


### PR DESCRIPTION
## Summary
- allow preprocessing CLI to load overrides from a JSON config file and generate summaries before indexing
- integrate chunk and section summaries into vector/BM25 metadata for improved retrieval
- document new config file workflow in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a4e0955c83308003d14dcccc7a93