### PR TITLE
refactor: relocate CLI scripts

### DIFF
--- a/scripts/preprocess_pdf.py
+++ b/scripts/preprocess_pdf.py
@@ -2,9 +2,9 @@ import sys
 from pathlib import Path
 
 # Allow running the script directly without installing the package
-sys.path.append(str(Path(__file__).resolve().parent / "src"))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from rag_chatbot.cli import main
+from rag_chatbot.preprocess_cli import main
 
 if __name__ == "__main__":
     main()

--- a/scripts/rag_pdf_ollama.py
+++ b/scripts/rag_pdf_ollama.py
@@ -2,9 +2,9 @@ import sys
 from pathlib import Path
 
 # Allow running the script directly without installing the package
-sys.path.append(str(Path(__file__).resolve().parent / "src"))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from rag_chatbot.preprocess_cli import main
+from rag_chatbot.cli import main
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- move preprocessing and chatbot runner scripts into scripts directory
- adjust sys.path handling for new location

## Testing
- `python scripts/preprocess_pdf.py --help`
- `python scripts/rag_pdf_ollama.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b1d62c3c2883309d50f903fe9c259d