### PR TITLE
Fix cross-encoder reranker returning query strings

### DIFF
--- a/src/rag_chatbot/reranking.py
+++ b/src/rag_chatbot/reranking.py
@@ -46,10 +46,10 @@ class CrossEncoderReranker(BaseReranker):
         self.model = get_cross_encoder(model_name, **kwargs)
 
     def rerank(self, ix: Index, query: str, candidate_ids: List[str]) -> List[str]:
-        pairs = [(query, ix.chunks[cid].text) for cid in candidate_ids if cid in ix.chunks]
-        if not pairs:
+        filtered_ids = [cid for cid in candidate_ids if cid in ix.chunks]
+        if not filtered_ids:
             return candidate_ids
+        pairs = [(query, ix.chunks[cid].text) for cid in filtered_ids]
         scores = self.model.predict(pairs)
-        ids = [cid for cid, _ in pairs]
-        ranked = [cid for _, cid in sorted(zip(scores, ids), key=lambda x: x[0], reverse=True)]
+        ranked = [cid for _, cid in sorted(zip(scores, filtered_ids), key=lambda x: x[0], reverse=True)]
         return ranked


### PR DESCRIPTION
## Summary
- fix cross-encoder reranker to return candidate chunk ids instead of query strings

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1dbcbc3908330b45a63b95715a16f