### PR TITLE
Improve summary prompts and hierarchical section summaries

### DIFF
--- a/configs/prompts/summarize_chunk.txt
+++ b/configs/prompts/summarize_chunk.txt
@@ -1,3 +1,4 @@
 Summarize the following text in one or two sentences.
+Respond with the summary only; do not include any introduction or preface.
 
 {text}

--- a/configs/prompts/summarize_section.txt
+++ b/configs/prompts/summarize_section.txt
@@ -1,3 +1,4 @@
 Provide a brief summary for the section titled "{title}" using the text below.
+Respond with the summary only; do not include any introduction or preface.
 
 {text}

--- a/src/rag_chatbot/summary.py
+++ b/src/rag_chatbot/summary.py
@@ -18,19 +18,29 @@ def build_summaries(chunks: List[Chunk], cfg: Config) -> Dict[str, Dict[str, str
 
     chunk_summaries: Dict[str, str] = {}
     for ch in chunks:
-        prompt = registry.get("summarize_chunk", "Summarize:\n{text}")
+        prompt = registry.get(
+            "summarize_chunk",
+            "Summarize the following text in one or two sentences. Respond with the summary only:\n{text}",
+        )
         chunk_summaries[ch.id] = llm.invoke(prompt.format(text=ch.text)).strip()
 
     by_section: Dict[str, List[Chunk]] = defaultdict(list)
+    title_by_num: Dict[str, str] = {}
     for ch in chunks:
-        by_section[ch.heading_num].append(ch)
+        # record title for this heading number
+        title_by_num.setdefault(ch.heading_num, ch.heading_title)
+        parts = ch.heading_num.split(".")
+        for i in range(1, len(parts) + 1):
+            prefix = ".".join(parts[:i])
+            by_section[prefix].append(ch)
 
     section_summaries: Dict[str, str] = {}
     for num, chs in by_section.items():
         text = "\n\n".join(c.text for c in chs)
-        title = chs[0].heading_title
+        title = title_by_num.get(num, chs[0].heading_title)
         prompt = registry.get(
-            "summarize_section", "Summarize section '{title}':\n{text}"
+            "summarize_section",
+            "Provide a brief summary for the section titled '{title}'. Respond with the summary only:\n{text}",
         )
         section_summaries[num] = llm.invoke(
             prompt.format(title=title, text=text)


### PR DESCRIPTION
## Summary
- refine chunk and section prompts to request only the summary, avoiding introductory phrases
- build section summaries by aggregating text from subsections, allowing chapter summaries to cover all nested content

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b1dfd57a7c8330b61b595345cdb154